### PR TITLE
Add PyInstaller build script and assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.spec
+
+# Logs
+*.log
+
+# Virtual environments
+venv/
+env/
+

--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ This tool automates the process for creating ingest files for the Cetamura Digit
 - **Log Review:** Check the `batch_tool.log` for detailed error messages and processing steps.
 - **Permissions:** Ensure you have permission to read and write files in the selected directories.
 
+
+## Building a Standalone Executable
+
+The application can be bundled into a single executable using [PyInstaller](https://pyinstaller.org/).
+
+1. Install the required packages:
+   ```bash
+   pip install pyinstaller Pillow
+   ```
+2. From the repository root, run the build script or PyInstaller directly:
+   ```bash
+   ./build_exe.sh
+   # or
+   pyinstaller --onefile --noconsole src/main.py
+   ```
+
+The resulting binary will be placed in the `dist/` directory. Optional icon and logo files can be added to the `assets/` folder so they are included in the executable.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,1 @@
+Place optional icon (.ico) and logo (.png) files here so PyInstaller can bundle them.

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Build the Tkinter GUI into a single executable.
+# Requires PyInstaller to be installed (pip install pyinstaller Pillow)
+pyinstaller --onefile --noconsole src/main.py

--- a/src/main.py
+++ b/src/main.py
@@ -137,7 +137,8 @@ root_window.geometry("600x500")
 
 # Set the window icon (favicon)
 try:
-    icon_path = Path("C:/Users/saa24b/Downloads/FSU_Lockup_W_V_solid_rgb.ico")
+    # Look for an optional icon in the local assets directory
+    icon_path = Path(__file__).resolve().parent / "../assets/app.ico"
     if icon_path.exists():
         icon_image = Image.open(icon_path).resize((32, 32), Image.LANCZOS)
         root_window.iconphoto(False, ImageTk.PhotoImage(icon_image))
@@ -147,7 +148,8 @@ except Exception as e:
     logging.error(f"Error loading window icon: {e}")
 
 try:
-    logo_path = Path("C:/Users/saa24b/Downloads/FSU_Lockup_W_V_solid_rgb.png")
+    # Optional logo displayed at the top of the window
+    logo_path = Path(__file__).resolve().parent / "../assets/app.png"
     if logo_path.exists():
         logo_image = Image.open(logo_path).resize((400, 100), Image.LANCZOS)
         logo_photo = ImageTk.PhotoImage(logo_image)


### PR DESCRIPTION
## Summary
- document how to build a standalone executable
- add `.gitignore` and a helper `build_exe.sh`
- look for optional icon/logo in `assets` directory

## Testing
- `pip install Pillow`
- `pytest -q` *(fails: cannot import name 'update_manifest')*

------
https://chatgpt.com/codex/tasks/task_e_68701dc2863c8323839b0b4f79164663